### PR TITLE
Adds new rake tasks to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,16 @@ Your project should load, but since there's no transcripts, all you'll see is a 
 
 This section will assume you are using the [American Archive of Public Broadcasting](https://github.com/WGBH/AAPB2) as the data source for importing transcripts.
 
+All of the rake tasks in "Creating a manifest file", "Downloading transcripts", "Converting transcripts", and "Importing transcripts" have been wrapped in to a single process for WGBH AAPB transcripts.
+
+**If you are importing AAPB transcripts in to a project, you can run one rake task:**
+
+```
+bundle exec rake aapb:ingest_guids['/path/to/file.txt','my-project']
+```
+
+This task will create a manifest file for AAPB records, download, convert, and import the transcripts.
+
 ### Creating your Collections
 
 The Collections for the transcript editor need to be created prior to uploading any transcripts or additional data.
@@ -188,6 +198,14 @@ And any new converters should be written to process this same format.
    - In the `vendor_identifier` column, enter the name of the `.vtt` file, e.g. `transcript_1234.vtt`
    - If you have not already, run the `rake transcripts:load['my-project','the_manifest_file.csv']` task on your manifest file to create entries for your transcripts
 3. Finally, run `rake webvtt:read['my-project']` which will import all the `.vtt` files that have not already been processed
+
+## Deleting transcripts
+
+To make it easier to mass delete AAPB transcripts that have been erroneously uploaded, we created a rake task to remove a list of AAPB GUIDS in a text file.
+
+```
+bundle exec rake aapb:delete_guids['/path/to/file.txt']
+```
 
 ## Customizing your project
 


### PR DESCRIPTION
Adds 2 new rake tasks to README. One task wraps up all the tasks needed to ingest AAPB GUIDs in to a project. The second deletes transcripts based on their GUIDs.