### PR TITLE
change display from original to guess

### DIFF
--- a/project/fix_it_plus/project.json
+++ b/project/fix_it_plus/project.json
@@ -23,7 +23,7 @@
     "minLinesForConsensus": 2,
     "minLinesForConsensusNoEdits": 2,
     "minPercentConsensus": 0.5,
-    "lineDisplayMethod": "original",
+    "lineDisplayMethod": "guess",
     "superUserHiearchy": 50
   },
   "menus": {


### PR DESCRIPTION
as per the documentation, I changed "original" to "guess" so that the line shown to the second editors will not be the original machine-generated line, but will be the best guess line.